### PR TITLE
Modify tor options and initializing steps to re use adress configuration value at most

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -5,6 +5,9 @@ address = "0.0.0.0:9000"
 # Enable tor.
 tor=false
 
+# Path to the tor privte key path, leave it empty to store your key within your store.
+privatekey=""
+
 # No trailing slashes.
 root_url = "http://localhost:9000"
 

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -1,6 +1,9 @@
 [app]
-# Address to listen, use "tor" to run an hidden service.
+# Address to listen.
 address = "0.0.0.0:9000"
+
+# Enable tor.
+tor=false
 
 # No trailing slashes.
 root_url = "http://localhost:9000"

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -45,6 +45,8 @@ type Config struct {
 	RoomAge           time.Duration `koanf:"room_age"`
 	SessionCookie     string        `koanf:"session_cookie"`
 	Storage           string        `koanf:"storage"`
+
+	Tor bool `koanf:"tor"`
 }
 
 // Hub acts as the controller and container for all chat rooms.

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -46,7 +46,8 @@ type Config struct {
 	SessionCookie     string        `koanf:"session_cookie"`
 	Storage           string        `koanf:"storage"`
 
-	Tor bool `koanf:"tor"`
+	Tor        bool   `koanf:"tor"`
+	PrivateKey string `koanf:"privatekey"`
 }
 
 // Hub acts as the controller and container for all chat rooms.

--- a/main.go
+++ b/main.go
@@ -236,12 +236,12 @@ func main() {
 	}
 
 	if ko.Bool("onion") {
-		pk, err := getOrCreatePK(store)
+		pk, err := loadTorPK(app.cfg, store)
 		if err != nil {
-			logger.Fatal(err)
+			logger.Fatalf("could not read or write the private key: %v", err)
 		}
 		fmt.Printf("http://%v.onion\n", onionAddr(pk))
-		os.Exit(0)
+		return // to allow for defers to execute
 	}
 
 	app.hub = hub.NewHub(app.cfg, store, logger)
@@ -277,9 +277,9 @@ func main() {
 	}
 
 	if app.cfg.Tor {
-		pk, err := getOrCreatePK(store)
+		pk, err := loadTorPK(app.cfg, store)
 		if err != nil {
-			logger.Fatalf("could not create the private key file: %v", err)
+			logger.Fatalf("could not read or write the private key: %v", err)
 		}
 
 		srv := &torServer{

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -155,13 +156,7 @@ func initFS(staticDir string) stuffbin.FileSystem {
 func catchInterrupts() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL)
-	go func() {
-		for sig := range c {
-			// Shutdown.
-			logger.Printf("shutting down: %v", sig)
-			os.Exit(0)
-		}
-	}()
+	logger.Printf("shutting down: %v", <-c)
 }
 
 func newConfigFile() error {
@@ -275,31 +270,40 @@ func main() {
 	})
 
 	// Start the app.
-	var srv interface {
-		ListenAndServe() error
+	lnAddr := ko.String("app.address")
+	ln, err := net.Listen("tcp", lnAddr)
+	if err != nil {
+		logger.Fatalf("couldn't listen address %q: %v", lnAddr, err)
 	}
 
-	if appAddress := ko.String("app.address"); appAddress == "tor" {
+	if app.cfg.Tor {
 		pk, err := getOrCreatePK(store)
 		if err != nil {
 			logger.Fatalf("could not create the private key file: %v", err)
 		}
 
-		srv = &torServer{
+		srv := &torServer{
 			PrivateKey: pk,
 			Handler:    r,
 		}
-		logger.Printf("starting server on http://%v.onion", onionAddr(pk))
+		onionAddr := fmt.Sprintf("http://%v.onion", onionAddr(pk))
+		logger.Printf("starting hidden service on %v", onionAddr)
+		go func() {
+			if err := srv.Serve(ln); err != nil {
+				logger.Fatalf("couldn't serve hidden service %q: %v", onionAddr, err)
+			}
+		}()
+	}
 
-	} else {
-		srv = &http.Server{
-			Addr:    appAddress,
-			Handler: r,
+	srv := http.Server{
+		Handler: r,
+	}
+	logger.Printf("starting server on http://%v", lnAddr)
+	go func() {
+		if err := srv.Serve(ln); err != nil {
+			logger.Fatalf("couldn't serve: %v", err)
 		}
-		logger.Printf("starting server on http://%v", appAddress)
-	}
+	}()
 
-	if err := srv.ListenAndServe(); err != nil {
-		logger.Fatalf("couldn't start server: %v", err)
-	}
+	catchInterrupts()
 }

--- a/tor.go
+++ b/tor.go
@@ -10,14 +10,23 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/clementauger/tor-prebuilt/embedded"
 	"github.com/cretz/bine/tor"
 	"github.com/cretz/bine/torutil"
 	tued25519 "github.com/cretz/bine/torutil/ed25519"
+	"github.com/knadh/niltalk/internal/hub"
 	"github.com/knadh/niltalk/store"
 )
+
+func loadTorPK(cfg *hub.Config, store store.Store) (pk ed25519.PrivateKey, err error) {
+	if cfg.PrivateKey != "" {
+		return getOrCreatePKFile(cfg.PrivateKey)
+	}
+	return getOrCreatePK(store)
+}
 
 func getOrCreatePK(store store.Store) (privateKey ed25519.PrivateKey, err error) {
 	key := "onionkey"
@@ -49,6 +58,41 @@ func getOrCreatePK(store store.Store) (privateKey ed25519.PrivateKey, err error)
 		}
 	}
 	return privateKey, err
+}
+
+func getOrCreatePKFile(fpath string) (privateKey ed25519.PrivateKey, err error) {
+	if _, err := os.Stat(fpath); os.IsNotExist(err) {
+		_, privateKey, err = ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			return nil, err
+		}
+		var x509Encoded []byte
+		x509Encoded, err = x509.MarshalPKCS8PrivateKey(privateKey)
+		if err != nil {
+			return nil, err
+		}
+		pemEncoded := pem.EncodeToMemory(&pem.Block{Type: "ED25519 PRIVATE KEY", Bytes: x509Encoded})
+		ioutil.WriteFile(fpath, pemEncoded, os.ModePerm)
+	} else {
+		var d []byte
+		d, err = ioutil.ReadFile(fpath)
+		if err != nil {
+			return nil, err
+		}
+		block, _ := pem.Decode(d)
+		x509Encoded := block.Bytes
+		var tPk interface{}
+		tPk, err = x509.ParsePKCS8PrivateKey(x509Encoded)
+		if err != nil {
+			return nil, err
+		}
+		if x, ok := tPk.(ed25519.PrivateKey); ok {
+			privateKey = x
+		} else {
+			return nil, fmt.Errorf("invalid key type %T wanted ed25519.PrivateKey", tPk)
+		}
+	}
+	return privateKey, nil
 }
 
 type torServer struct {


### PR DESCRIPTION
it changes the startup sequence and configuration options of tor 
in order to re use address configuration value to always setup a local listener, 
this helps to predict the local address and 
will be useful in scenarios where you want 
to display a link to the local user to its local instance 
from outside the browser.